### PR TITLE
Fixed some units, added configureable terrian rings and option for different dump1090 endpoint

### DIFF
--- a/public_html/config.js
+++ b/public_html/config.js
@@ -172,11 +172,11 @@ ShowSleafordRange    = false ;  // This shows a range layer based on 53N -0.5W A
 SleafordMySql        = false ;  // Don't set this without reviewing the code - it is for me and a local mySql server on 192.168.1.11
 // ----------------------------------------------------------------------------------------------------------------------------
 
-UseDefaultTerrianRings = false; // default Terrian rings color, otherwise colored by altidute (color defined in TerrianColorByAlt)
-UseTerrianLineDash = true;      // true: dashed or false: solid terrian rings
+UseDefaultTerrianRings = true; // default Terrian rings color, otherwise colored by altitude (color defined in TerrianColorByAlt)
+UseTerrianLineDash = false;      // true: dashed or false: solid terrian rings
 TerrianLineWidth = 1;           // line width of terrian rings
-TerrianAltidutes = [9842,39370];// altidutes in ft as in alt parameter TerrianColorByAlt, replace XXXXXXX with your code: sudo wget -O /usr/share/dump1090-fa/html/upintheair.json "www.heywhatsthat.com/api/upintheair.json?id=XXXXXXX&refraction=0.25&alts=3000,12000" 
-TerrianColorByAlt = {           // colours depending on altidute (UseDefaultTerrianRings must be false and TerrianAltidutes must be set), default same as colours of planes in air, alt in ft
+TerrianAltitudes = [9842,39370];// altitudes in ft as in alt parameter TerrianColorByAlt, replace XXXXXXX with your code: sudo wget -O /usr/share/dump1090-fa/html/upintheair.json "www.heywhatsthat.com/api/upintheair.json?id=XXXXXXX&refraction=0.25&alts=3000,12000" 
+TerrianColorByAlt = {           // colours depending on altitude (UseDefaultTerrianRings must be false and TerrianAltitudes must be set), default same as colours of planes in air, alt in ft
         h: [ { alt: 2000,  val: 20 },    // orange
              { alt: 10000, val: 140 },   // light green
              { alt: 40000, val: 300 } ], // magenta

--- a/public_html/config.js
+++ b/public_html/config.js
@@ -172,11 +172,11 @@ ShowSleafordRange    = false ;  // This shows a range layer based on 53N -0.5W A
 SleafordMySql        = false ;  // Don't set this without reviewing the code - it is for me and a local mySql server on 192.168.1.11
 // ----------------------------------------------------------------------------------------------------------------------------
 
-UseDefaultTerrianRings = true; // default Terrian rings color, otherwise colored by altitude (color defined in TerrianColorByAlt)
-UseTerrianLineDash = false;      // true: dashed or false: solid terrian rings
-TerrianLineWidth = 1;           // line width of terrian rings
-TerrianAltitudes = [9842,39370];// altitudes in ft as in alt parameter TerrianColorByAlt, replace XXXXXXX with your code: sudo wget -O /usr/share/dump1090-fa/html/upintheair.json "www.heywhatsthat.com/api/upintheair.json?id=XXXXXXX&refraction=0.25&alts=3000,12000" 
-TerrianColorByAlt = {           // colours depending on altitude (UseDefaultTerrianRings must be false and TerrianAltitudes must be set), default same as colours of planes in air, alt in ft
+UseDefaultTerrianRings  = true;         // default Terrian rings color, otherwise colored by altitude (color defined in TerrianColorByAlt)
+UseTerrianLineDash      = false;        // true: dashed or false: solid terrian rings
+TerrianLineWidth        = 1;            // line width of terrian rings
+TerrianAltitudes        = [9842,39370]; // altitudes in ft as in alt parameter TerrianColorByAlt, replace XXXXXXX with your code: sudo wget -O /usr/share/dump1090-fa/html/upintheair.json "www.heywhatsthat.com/api/upintheair.json?id=XXXXXXX&refraction=0.25&alts=3000,12000" 
+TerrianColorByAlt       = {             // colours depending on altitude (UseDefaultTerrianRings must be false and TerrianAltitudes must be set), default same as colours of planes in air, alt in ft
         h: [ { alt: 2000,  val: 20 },    // orange
              { alt: 10000, val: 140 },   // light green
              { alt: 40000, val: 300 } ], // magenta
@@ -184,7 +184,7 @@ TerrianColorByAlt = {           // colours depending on altitude (UseDefaultTerr
         l: 50,
 };
 
-ShowSiteRingDistanceText = true; // show the distance text in site rings
+ShowSiteRingDistanceText = false;       // show the distance text in site rings
 
 // for this you have to change /etc/lighttpd/conf-enabled/89-dump1090-fa.conf : commenting out the filter $HTTP["url"] =~ "^/dump1090-fa/data/.*\.json$"  and always send the response header
 // maybe filter is not correct --- Help wanted

--- a/public_html/config.js
+++ b/public_html/config.js
@@ -185,3 +185,11 @@ TerrianColorByAlt = {           // colours depending on altidute (UseDefaultTerr
 };
 
 ShowSiteRingDistanceText = true; // show the distance text in site rings
+
+// for this you have to change /etc/lighttpd/conf-enabled/89-dump1090-fa.conf : commenting out the filter $HTTP["url"] =~ "^/dump1090-fa/data/.*\.json$"  and always send the response header
+// maybe filter is not correct --- Help wanted
+// the last 3 lines should look like this without the //
+// #$HTTP["url"] =~ "^/dump1090-fa/data/.*\.json$" {
+//       setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
+// #}
+EndpointDump1090        = "";    // insert here endpoint to other computer where dump1090 is running (ex: http://192.168.1.152:8080/), leave it empty if it is running here

--- a/public_html/config.js
+++ b/public_html/config.js
@@ -171,3 +171,17 @@ ShowMyFindsLayer     = false ;	// Private plot (non-aircraft related)
 ShowSleafordRange    = false ;  // This shows a range layer based on 53N -0.5W A more reasltic range layer for my antenna location --  AK9T
 SleafordMySql        = false ;  // Don't set this without reviewing the code - it is for me and a local mySql server on 192.168.1.11
 // ----------------------------------------------------------------------------------------------------------------------------
+
+UseDefaultTerrianRings = false; // default Terrian rings color, otherwise colored by altidute (color defined in TerrianColorByAlt)
+UseTerrianLineDash = true;      // true: dashed or false: solid terrian rings
+TerrianLineWidth = 1;           // line width of terrian rings
+TerrianAltidutes = [9842,39370];// altidutes in ft as in alt parameter TerrianColorByAlt, replace XXXXXXX with your code: sudo wget -O /usr/share/dump1090-fa/html/upintheair.json "www.heywhatsthat.com/api/upintheair.json?id=XXXXXXX&refraction=0.25&alts=3000,12000" 
+TerrianColorByAlt = {           // colours depending on altidute (UseDefaultTerrianRings must be false and TerrianAltidutes must be set), default same as colours of planes in air, alt in ft
+        h: [ { alt: 2000,  val: 20 },    // orange
+             { alt: 10000, val: 140 },   // light green
+             { alt: 40000, val: 300 } ], // magenta
+        s: 85,
+        l: 50,
+};
+
+ShowSiteRingDistanceText = true; // show the distance text in site rings

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -140,7 +140,7 @@
 
 							<tr class="infoblock_body">
 								<td>(with positions): <span id="dump1090_total_ac_positions">n/a</span></td>
-								<td>Max : <span id="dump1090_max_range">n/a</span> Nm</td> <!-- Ref: AK9S -->
+								<td>Max: <span id="dump1090_max_range">n/a</span> <span class="distanceUnit"></span></td> <!-- Ref: AK9S -->
 								<!-- <td>History: <span id="dump1090_total_history">n/a</span> positions</td> Ref: AK9S -->
 							</tr>
 						</table>

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -152,7 +152,7 @@ function fetchData() {
                 return;
         }
 
-	FetchPending = $.ajax({ url: 'data/aircraft.json',
+    FetchPending = $.ajax({ url: EndpointDump1090 + 'data/aircraft.json',
                                 timeout: 5000,
                                 cache: false,
                                 dataType: 'json' });
@@ -288,8 +288,9 @@ function initialize() {
 
         // Get receiver metadata, reconfigure using it, then continue
         // with initialization
-        $.ajax({ url: 'data/receiver.json',
-                 timeout: 5000,
+        $.ajax({ url: EndpointDump1090 + 'data/receiver.json',
+                crossDomain: true,
+                timeout: 5000,
                  cache: false,
                  dataType: 'json' })
 
@@ -374,8 +375,9 @@ function load_history_item(i) {
         // Ref: AK9Y  --  console.log("Loading history #" + i);
         $("#loader_progress").attr('value',i);
 
-        $.ajax({ url: 'data/history_' + i + '.json',
-                 timeout: 5000,
+        $.ajax({ url: EndpointDump1090 + 'data/history_' + i + '.json',
+                crossDomain: true,
+                timeout: 5000,
                  cache: false,
                  dataType: 'json' })
 

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -289,7 +289,6 @@ function initialize() {
         // Get receiver metadata, reconfigure using it, then continue
         // with initialization
         $.ajax({ url: EndpointDump1090 + 'data/receiver.json',
-                crossDomain: true,
                 timeout: 5000,
                  cache: false,
                  dataType: 'json' })
@@ -376,7 +375,6 @@ function load_history_item(i) {
         $("#loader_progress").attr('value',i);
 
         $.ajax({ url: EndpointDump1090 + 'data/history_' + i + '.json',
-                crossDomain: true,
                 timeout: 5000,
                  cache: false,
                  dataType: 'json' })
@@ -1467,11 +1465,11 @@ function initialize_map() {
             else {
                 ringStyle = [];
                 
-                for(var i = 0; i< TerrianAltidutes.length; ++i) {
+                for(var i = 0; i< TerrianAltitudes.length; ++i) {
                     ringStyle.push(new ol.style.Style({
                         fill: null,
                         stroke: new ol.style.Stroke({
-                            color: getTerrianColorByAlti(TerrianAltidutes[i]),
+                            color: getTerrianColorByAlti(TerrianAltitudes[i]),
                             lineDash: UseTerrianLineDash ? [4,4] : null,
                             width: TerrianLineWidth
                         })


### PR DESCRIPTION
I have made some improvements, maybe there is something interesting stuff for you and you want to merge (otherwise just reject this pull request)

I fixed the hardcoded unit NM in max range which is wrong if you change the units to metrics for example.
When you change the units also mouse point displays now the distance to the site in the selected units.
Option to show the distance of the site rings

Terrian Rings:
I created the options to change the terrian rings in the config file:
* dashed or solid lines
* line width
* lines in different colors, depending on its altitudes (colors can be configured the same as the not simplified colors of the airplanes in the air)
* or just leave it as it is (default config)
(Hopefully my description in the configuration file is understandable)

Added the option to use a different dump1090 endpoint (ex for testing). For working correctly, a configuration in lighttpd must be changed because the used filter for the header seems not to work.

In the default configuration everything stays at it is without my changes.